### PR TITLE
The restful handler of storageprovider

### DIFF
--- a/src/entity/storage_provider.go
+++ b/src/entity/storage_provider.go
@@ -1,6 +1,8 @@
 package entity
 
 import (
+	"time"
+
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -18,6 +20,7 @@ type StorageProvider struct {
 	Type        string        `bson:"type" json:"type"`
 	DisplayName string        `bson:"displayName" json:"displayName"`
 	NFSStorageProvider
+	CreatedAt *time.Time `bson:"createdAt,omitempty" json:"createdAt,omitempty"`
 }
 
 //GetCollection - get model mongo collection name.

--- a/src/entity/storage_provider.go
+++ b/src/entity/storage_provider.go
@@ -19,8 +19,8 @@ type StorageProvider struct {
 	ID          bson.ObjectId `bson:"_id,omitempty" json:"id"`
 	Type        string        `bson:"type" json:"type"`
 	DisplayName string        `bson:"displayName" json:"displayName"`
+	CreatedAt   *time.Time    `bson:"createdAt,omitempty" json:"createdAt,omitempty"`
 	NFSStorageProvider
-	CreatedAt *time.Time `bson:"createdAt,omitempty" json:"createdAt,omitempty"`
 }
 
 //GetCollection - get model mongo collection name.

--- a/src/entity/storage_provider.go
+++ b/src/entity/storage_provider.go
@@ -1,0 +1,26 @@
+package entity
+
+import (
+	"gopkg.in/mgo.v2/bson"
+)
+
+const (
+	StorageProviderCollectionName string = "storage_provider"
+)
+
+type NFSStorageProvider struct {
+	IP   string `bson:"ip" json:"ip"`
+	PATH string `bson:"path" json:"path"`
+}
+
+type StorageProvider struct {
+	ID          bson.ObjectId `bson:"_id,omitempty" json:"id"`
+	Type        string        `bson:"type" json:"type"`
+	DisplayName string        `bson:"displayName" json:"displayName"`
+	NFSStorageProvider
+}
+
+//GetCollection - get model mongo collection name.
+func (m StorageProvider) GetCollection() string {
+	return StorageProviderCollectionName
+}

--- a/src/server/handler_storage_provider.go
+++ b/src/server/handler_storage_provider.go
@@ -13,7 +13,7 @@ import (
 )
 
 func CreateStorageProvider(ctx *web.Context) {
-	as, req, resp := ctx.ServiceProvider, ctx.Request, ctx.Response
+	sp, req, resp := ctx.ServiceProvider, ctx.Request, ctx.Response
 
 	storageProvider := entity.StorageProvider{}
 	if err := req.ReadEntity(&storageProvider); err != nil {
@@ -22,11 +22,11 @@ func CreateStorageProvider(ctx *web.Context) {
 		return
 	}
 
-	session := as.Mongo.NewSession()
+	session := sp.Mongo.NewSession()
 	defer session.Close()
 	// Check whether this displayname has been used
 	query := bson.M{"displayName": storageProvider.DisplayName}
-	count, err := session.Count(entity.NetworkCollectionName, query)
+	count, err := session.Count(entity.StorageProviderCollectionName, query)
 	if err != nil && err.Error() != mgo.ErrNotFound.Error() {
 		logger.Error(err)
 		response.InternalServerError(req.Request, resp.ResponseWriter, err)

--- a/src/server/handler_storage_provider.go
+++ b/src/server/handler_storage_provider.go
@@ -1,0 +1,55 @@
+package server
+
+import (
+	"fmt"
+
+	"github.com/linkernetworks/logger"
+	"github.com/linkernetworks/utils/timeutils"
+	"github.com/linkernetworks/vortex/src/entity"
+	response "github.com/linkernetworks/vortex/src/net/http"
+	"github.com/linkernetworks/vortex/src/web"
+	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+)
+
+func CreateStorageProvider(ctx *web.Context) {
+	as, req, resp := ctx.ServiceProvider, ctx.Request, ctx.Response
+
+	storageProvider := entity.StorageProvider{}
+
+	if err := req.ReadEntity(&storageProvider); err != nil {
+		logger.Error(err)
+		response.BadRequest(req.Request, resp.ResponseWriter, err)
+		return
+	}
+
+	session := as.Mongo.NewSession()
+	defer session.Close()
+
+	// Check whether this displayname has been used
+	query := bson.M{"displayName": storageProvider.DisplayName}
+	count, err := session.Count(entity.NetworkCollectionName, query)
+	if err != nil && err.Error() != mgo.ErrNotFound.Error() {
+		logger.Error(err)
+		response.InternalServerError(req.Request, resp.ResponseWriter, err)
+		return
+	}
+
+	if count > 0 {
+		response.Conflict(req.Request, resp, fmt.Errorf("displayName: %s already existed", storageProvider.DisplayName))
+		return
+	}
+
+	storageProvider.ID = bson.NewObjectId()
+	storageProvider.CreatedAt = timeutils.Now()
+	if err := session.Insert(entity.StorageProviderCollectionName, &storageProvider); err != nil {
+		logger.Error(err)
+		response.InternalServerError(req.Request, resp.ResponseWriter, err)
+		return
+	}
+
+	resp.WriteEntity(ActionResponse{
+		Error:   false,
+		Message: "Create success",
+	})
+}

--- a/src/server/handler_storage_provider.go
+++ b/src/server/handler_storage_provider.go
@@ -16,7 +16,6 @@ func CreateStorageProvider(ctx *web.Context) {
 	as, req, resp := ctx.ServiceProvider, ctx.Request, ctx.Response
 
 	storageProvider := entity.StorageProvider{}
-
 	if err := req.ReadEntity(&storageProvider); err != nil {
 		logger.Error(err)
 		response.BadRequest(req.Request, resp.ResponseWriter, err)
@@ -25,7 +24,6 @@ func CreateStorageProvider(ctx *web.Context) {
 
 	session := as.Mongo.NewSession()
 	defer session.Close()
-
 	// Check whether this displayname has been used
 	query := bson.M{"displayName": storageProvider.DisplayName}
 	count, err := session.Count(entity.NetworkCollectionName, query)
@@ -34,7 +32,6 @@ func CreateStorageProvider(ctx *web.Context) {
 		response.InternalServerError(req.Request, resp.ResponseWriter, err)
 		return
 	}
-
 	if count > 0 {
 		response.Conflict(req.Request, resp, fmt.Errorf("displayName: %s already existed", storageProvider.DisplayName))
 		return

--- a/src/server/handler_storage_provider.go
+++ b/src/server/handler_storage_provider.go
@@ -28,7 +28,6 @@ func CreateStorageProvider(ctx *web.Context) {
 	query := bson.M{"displayName": storageProvider.DisplayName}
 	count, err := session.Count(entity.StorageProviderCollectionName, query)
 	if err != nil && err.Error() != mgo.ErrNotFound.Error() {
-		logger.Error(err)
 		response.InternalServerError(req.Request, resp.ResponseWriter, err)
 		return
 	}
@@ -40,7 +39,6 @@ func CreateStorageProvider(ctx *web.Context) {
 	storageProvider.ID = bson.NewObjectId()
 	storageProvider.CreatedAt = timeutils.Now()
 	if err := session.Insert(entity.StorageProviderCollectionName, &storageProvider); err != nil {
-		logger.Error(err)
 		response.InternalServerError(req.Request, resp.ResponseWriter, err)
 		return
 	}

--- a/src/server/handler_storage_provider_test.go
+++ b/src/server/handler_storage_provider_test.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	restful "github.com/emicklei/go-restful"
+	"github.com/linkernetworks/vortex/src/config"
+	"github.com/linkernetworks/vortex/src/entity"
+	"github.com/linkernetworks/vortex/src/serviceprovider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStorageProvider(t *testing.T) {
+	cf := config.MustRead("../../config/testing.json")
+	sp := serviceprovider.New(cf)
+
+	//Testing parameter
+	tName := "hello world"
+	tType := "nfs"
+	tIP := "1.2.3.4"
+	tPath := "/exports"
+	storageProvider := entity.StorageProvider{
+		Type:        tType,
+		DisplayName: tName,
+		NFSStorageProvider: entity.NFSStorageProvider{
+			IP:   tIP,
+			PATH: tPath,
+		},
+	}
+	session := sp.Mongo.NewSession()
+
+	bodyBytes, err := json.MarshalIndent(storageProvider, "", "  ")
+	assert.NoError(t, err)
+
+	bodyReader := strings.NewReader(string(bodyBytes))
+	httpRequest, err := http.NewRequest("POST", "http://localhost:7890/v1/storageprovider", bodyReader)
+	assert.NoError(t, err)
+
+	httpRequest.Header.Add("Content-Type", "application/json")
+	httpWriter := httptest.NewRecorder()
+	wc := restful.NewContainer()
+	service := newStorageProviderService(sp)
+	wc.Add(service)
+	wc.Dispatch(httpWriter, httpRequest)
+	defer session.Remove(entity.StorageProviderCollectionName, "displayName", tName)
+	assertResponseCode(t, http.StatusOK, httpWriter)
+}

--- a/src/server/handler_storage_provider_test.go
+++ b/src/server/handler_storage_provider_test.go
@@ -46,6 +46,19 @@ func TestCreateStorageProvider(t *testing.T) {
 	service := newStorageProviderService(sp)
 	wc.Add(service)
 	wc.Dispatch(httpWriter, httpRequest)
-	defer session.Remove(entity.StorageProviderCollectionName, "displayName", tName)
 	assertResponseCode(t, http.StatusOK, httpWriter)
+	//Empty data
+	//We use the new write but empty input
+	httpWriter = httptest.NewRecorder()
+	wc.Dispatch(httpWriter, httpRequest)
+	assertResponseCode(t, http.StatusBadRequest, httpWriter)
+	//Create again and it should fail since the name exist
+	bodyReader = strings.NewReader(string(bodyBytes))
+	httpRequest, err = http.NewRequest("POST", "http://localhost:7890/v1/storageprovider", bodyReader)
+	assert.NoError(t, err)
+	httpRequest.Header.Add("Content-Type", "application/json")
+	httpWriter = httptest.NewRecorder()
+	wc.Dispatch(httpWriter, httpRequest)
+	assertResponseCode(t, http.StatusConflict, httpWriter)
+	defer session.Remove(entity.StorageProviderCollectionName, "displayName", tName)
 }

--- a/src/server/handler_storage_provider_test.go
+++ b/src/server/handler_storage_provider_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/docker/docker/pkg/namesgenerator"
 	restful "github.com/emicklei/go-restful"
 	"github.com/linkernetworks/vortex/src/config"
 	"github.com/linkernetworks/vortex/src/entity"
@@ -19,7 +20,7 @@ func TestCreateStorageProvider(t *testing.T) {
 	sp := serviceprovider.New(cf)
 
 	//Testing parameter
-	tName := "hello world"
+	tName := namesgenerator.GetRandomName(0)
 	tType := "nfs"
 	tIP := "1.2.3.4"
 	tPath := "/exports"

--- a/src/server/route.go
+++ b/src/server/route.go
@@ -42,7 +42,7 @@ func newNetworkService(sp *serviceprovider.Container) *restful.WebService {
 
 func newStorageProviderService(sp *serviceprovider.Container) *restful.WebService {
 	webService := new(restful.WebService)
-	webService.Path("/v1/provisioner").Consumes(restful.MIME_JSON, restful.MIME_JSON).Produces(restful.MIME_JSON, restful.MIME_JSON)
+	webService.Path("/v1/storageprovider").Consumes(restful.MIME_JSON, restful.MIME_JSON).Produces(restful.MIME_JSON, restful.MIME_JSON)
 	webService.Route(webService.POST("/").To(handler.RESTfulServiceHandler(sp, CreateStorageProvider)))
 	return webService
 }

--- a/src/server/route.go
+++ b/src/server/route.go
@@ -16,6 +16,7 @@ func (a *App) AppRoute() *mux.Router {
 
 	container.Add(newVersionService(a.ServiceProvider))
 	container.Add(newNetworkService(a.ServiceProvider))
+	container.Add(newStorageProviderService(a.ServiceProvider))
 
 	router.PathPrefix("/v1/").Handler(container)
 	return router
@@ -36,5 +37,12 @@ func newNetworkService(sp *serviceprovider.Container) *restful.WebService {
 	webService.Route(webService.POST("/").To(handler.RESTfulServiceHandler(sp, CreateNetworkHandler)))
 	webService.Route(webService.PUT("/{id}").To(handler.RESTfulServiceHandler(sp, UpdateNetworkHandler)))
 	webService.Route(webService.DELETE("/{id}").To(handler.RESTfulServiceHandler(sp, DeleteNetworkHandler)))
+	return webService
+}
+
+func newStorageProviderService(sp *serviceprovider.Container) *restful.WebService {
+	webService := new(restful.WebService)
+	webService.Path("/v1/provisioner").Consumes(restful.MIME_JSON, restful.MIME_JSON).Produces(restful.MIME_JSON, restful.MIME_JSON)
+	webService.Route(webService.POST("/").To(handler.RESTfulServiceHandler(sp, CreateStorageProvider)))
 	return webService
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -69,6 +69,12 @@
 			"revisionTime": "2018-03-08T23:13:08Z"
 		},
 		{
+			"checksumSHA1": "mgmkUpfdKCjiPfSjUXE7Tg2HvBw=",
+			"path": "github.com/docker/docker/pkg/namesgenerator",
+			"revision": "af626ba08a4e11b0e140e7512ac2740b09833c29",
+			"revisionTime": "2018-06-22T02:08:08Z"
+		},
+		{
 			"checksumSHA1": "wPbKObbGzS/43nrskRaJVFVEW/A=",
 			"path": "github.com/ema/qdisc",
 			"revision": "b307c22d3ce761d351b6e6270b50195b44ee9248",


### PR DESCRIPTION
The storage-provider is used to setup the storage for system and it should setup all resources we need for kubernetes (storageClass, storage-provisioner).
- In this patch, we only handle the mongo document.
- We only support the NFS now and it's easy to add other storage in the field.
   - For NFS, we will setup the deployment and storageClass for nfs-client provisioner.
   - For GlusterFS,  we only setup the storageClass for glusterFS provisioner