### PR TITLE
Create a deployment for storage.

### DIFF
--- a/src/entity/storage.go
+++ b/src/entity/storage.go
@@ -22,8 +22,8 @@ type Storage struct {
 	Type      StorageType   `bson:"type" json:"type"`
 	Name      string        `bson:"name" json:"name"`
 	CreatedAt *time.Time    `bson:"createdAt,omitempty" json:"createdAt,omitempty"`
-	NFS       NFSStorage    `bson:"nfs" json:"nfs"`
-	Fake      FakeStorage   `json:"fake"` //FakeNetwork, for restful testing.
+	NFS       *NFSStorage   `bson:"nfs,omitempty" json:"nfs,omitempty"`
+	Fake      *FakeStorage  `bson:"fake,omitempty" json:"fake,omitempty"` //FakeStorage, for restful testing.
 }
 
 //GetCollection - get model mongo collection name.

--- a/src/kubernetes/deployment.go
+++ b/src/kubernetes/deployment.go
@@ -13,3 +13,7 @@ func (kc *KubeCtl) CreateDeployment(deployment *appsv1.Deployment) (*appsv1.Depl
 func (kc *KubeCtl) GetDeployment(name string) (*appsv1.Deployment, error) {
 	return kc.Clientset.AppsV1().Deployments(kc.Namespace).Get(name, metav1.GetOptions{})
 }
+
+func (kc *KubeCtl) DeleteDeployment(name string) error {
+	return kc.Clientset.AppsV1().Deployments(kc.Namespace).Delete(name, &metav1.DeleteOptions{})
+}

--- a/src/kubernetes/deployment_test.go
+++ b/src/kubernetes/deployment_test.go
@@ -31,7 +31,6 @@ func (suite *KubeCtlDeploymentTestSuite) SetupSuite() {
 
 func (suite *KubeCtlDeploymentTestSuite) TearDownSuite() {}
 func (suite *KubeCtlDeploymentTestSuite) TestCreateDeployment() {
-
 	var replicas int32
 	replicas = 3
 	name := namesgenerator.GetRandomName(0)
@@ -52,6 +51,35 @@ func (suite *KubeCtlDeploymentTestSuite) TestCreateDeployment() {
 	suite.NoError(err)
 	suite.NotNil(deploy)
 	suite.Equal(replicas, *deploy.Spec.Replicas)
+}
+
+func (suite *KubeCtlDeploymentTestSuite) TestDeleteDeployment() {
+	var replicas int32
+	replicas = 3
+	name := namesgenerator.GetRandomName(0)
+	deployment := appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+		},
+		Status: appsv1.DeploymentStatus{},
+	}
+	ret, err := suite.kubectl.CreateDeployment(&deployment)
+	suite.NoError(err)
+	suite.NotNil(ret)
+
+	deploy, err := suite.kubectl.GetDeployment(name)
+	suite.NoError(err)
+	suite.NotNil(deploy)
+	suite.Equal(replicas, *deploy.Spec.Replicas)
+
+	err = suite.kubectl.DeleteDeployment(name)
+	suite.NoError(err)
+	deploy, err = suite.kubectl.GetDeployment(name)
+	suite.Error(err)
+	suite.Nil(deploy)
 }
 
 func TestDeploymentTestSuite(t *testing.T) {

--- a/src/server/handler_storage_test.go
+++ b/src/server/handler_storage_test.go
@@ -62,7 +62,7 @@ func (suite *StorageTestSuite) TestCreateStorage() {
 	storage := entity.Storage{
 		Type: entity.FakeStorageType,
 		Name: tName,
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			FakeParameter: "fake~",
 		},
 	}
@@ -103,14 +103,14 @@ func (suite *StorageTestSuite) TestCreateStorageFail() {
 		{"InvalidParameter", entity.Storage{
 			Name: namesgenerator.GetRandomName(0),
 			Type: entity.FakeStorageType,
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "",
 			}},
 			http.StatusBadRequest},
 		{"CreateFail", entity.Storage{
 			Name: namesgenerator.GetRandomName(0),
 			Type: entity.FakeStorageType,
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "Yo",
 				IWantFail:     true,
 			}},
@@ -118,7 +118,7 @@ func (suite *StorageTestSuite) TestCreateStorageFail() {
 		{"StorageTypeError", entity.Storage{
 			Name: namesgenerator.GetRandomName(0),
 			Type: "non-exist",
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "Yo",
 				IWantFail:     true,
 			}},
@@ -150,7 +150,7 @@ func (suite *StorageTestSuite) TestDeleteStorage() {
 		ID:   bson.NewObjectId(),
 		Type: entity.FakeStorageType,
 		Name: tName,
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			FakeParameter: "fake~",
 		},
 	}
@@ -198,7 +198,7 @@ func (suite *StorageTestSuite) TestDeleteStorageFail() {
 			ID:   bson.NewObjectId(),
 			Name: namesgenerator.GetRandomName(0),
 			Type: entity.FakeStorageType,
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "Yo-Delete-Fail",
 				IWantFail:     true,
 			}},
@@ -207,7 +207,7 @@ func (suite *StorageTestSuite) TestDeleteStorageFail() {
 			ID:   bson.NewObjectId(),
 			Name: namesgenerator.GetRandomName(0),
 			Type: "non-exist",
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "Yo-Delete-Fail",
 				IWantFail:     true,
 			}},
@@ -238,7 +238,7 @@ func (suite *StorageTestSuite) TestListStorage() {
 		storages = append(storages, entity.Storage{
 			Name: namesgenerator.GetRandomName(0),
 			Type: entity.FakeStorageType,
-			Fake: entity.FakeStorage{
+			Fake: &entity.FakeStorage{
 				FakeParameter: "Yo",
 				IWantFail:     false,
 			},

--- a/src/storageprovider/fake.go
+++ b/src/storageprovider/fake.go
@@ -10,21 +10,21 @@ type FakeStorageProvider struct {
 	entity.FakeStorage
 }
 
-func (fake FakeStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, net entity.Storage) error {
+func (fake FakeStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, net *entity.Storage) error {
 	if fake.FakeParameter == "" {
 		return fmt.Errorf("Fail to validate but don't worry, I'm fake storage provider")
 	}
 	return nil
 }
 
-func (fake FakeStorageProvider) CreateStorage(sp *serviceprovider.Container, net entity.Storage) error {
+func (fake FakeStorageProvider) CreateStorage(sp *serviceprovider.Container, net *entity.Storage) error {
 	if fake.IWantFail {
 		return fmt.Errorf("Fail to create storage but don't worry, I'm fake storage provider")
 	}
 	return nil
 }
 
-func (fake FakeStorageProvider) DeleteStorage(sp *serviceprovider.Container, net entity.Storage) error {
+func (fake FakeStorageProvider) DeleteStorage(sp *serviceprovider.Container, net *entity.Storage) error {
 	if fake.IWantFail {
 		return fmt.Errorf("Fail to delete storage but don't worry, I'm fake storage provider")
 	}

--- a/src/storageprovider/fake_test.go
+++ b/src/storageprovider/fake_test.go
@@ -16,7 +16,7 @@ func TestStorageValidateBeforeCreating(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	err = fake.ValidateBeforeCreating(nil, entity.Storage{})
+	err = fake.ValidateBeforeCreating(nil, &entity.Storage{})
 	assert.NoError(t, err)
 }
 
@@ -29,7 +29,7 @@ func TestFakeStorageCreating(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	err = fake.CreateStorage(nil, entity.Storage{})
+	err = fake.CreateStorage(nil, &entity.Storage{})
 	assert.NoError(t, err)
 }
 
@@ -41,7 +41,7 @@ func TestFakeStorageValidateBeforeCreatingFail(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	err = fake.ValidateBeforeCreating(nil, entity.Storage{})
+	err = fake.ValidateBeforeCreating(nil, &entity.Storage{})
 	assert.Error(t, err)
 }
 
@@ -53,7 +53,7 @@ func TestFakeStorageCreatingFail(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	err = fake.CreateStorage(nil, entity.Storage{})
+	err = fake.CreateStorage(nil, &entity.Storage{})
 	assert.Error(t, err)
 }
 
@@ -63,7 +63,7 @@ func TestFakeStorageDelete(t *testing.T) {
 		Fake: entity.FakeStorage{},
 	})
 	assert.NoError(t, err)
-	err = fake.DeleteStorage(nil, entity.Storage{})
+	err = fake.DeleteStorage(nil, &entity.Storage{})
 	assert.NoError(t, err)
 }
 
@@ -75,6 +75,6 @@ func TestFakeStorageDeleteFail(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err)
-	err = fake.DeleteStorage(nil, entity.Storage{})
+	err = fake.DeleteStorage(nil, &entity.Storage{})
 	assert.Error(t, err)
 }

--- a/src/storageprovider/fake_test.go
+++ b/src/storageprovider/fake_test.go
@@ -11,7 +11,7 @@ import (
 func TestStorageValidateBeforeCreating(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			FakeParameter: "yes",
 		},
 	})
@@ -23,7 +23,7 @@ func TestStorageValidateBeforeCreating(t *testing.T) {
 func TestFakeStorageCreating(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			FakeParameter: "yes",
 			IWantFail:     false,
 		},
@@ -36,7 +36,7 @@ func TestFakeStorageCreating(t *testing.T) {
 func TestFakeStorageValidateBeforeCreatingFail(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			FakeParameter: "",
 		},
 	})
@@ -48,7 +48,7 @@ func TestFakeStorageValidateBeforeCreatingFail(t *testing.T) {
 func TestFakeStorageCreatingFail(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			IWantFail: true,
 		},
 	})
@@ -60,7 +60,7 @@ func TestFakeStorageCreatingFail(t *testing.T) {
 func TestFakeStorageDelete(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{},
+		Fake: &entity.FakeStorage{},
 	})
 	assert.NoError(t, err)
 	err = fake.DeleteStorage(nil, &entity.Storage{})
@@ -70,7 +70,7 @@ func TestFakeStorageDelete(t *testing.T) {
 func TestFakeStorageDeleteFail(t *testing.T) {
 	fake, err := GetStorageProvider(&entity.Storage{
 		Type: "fake",
-		Fake: entity.FakeStorage{
+		Fake: &entity.FakeStorage{
 			IWantFail: true,
 		},
 	})

--- a/src/storageprovider/nfs.go
+++ b/src/storageprovider/nfs.go
@@ -1,8 +1,10 @@
 package storageprovider
 
 import (
+	"fmt"
 	"github.com/linkernetworks/vortex/src/entity"
 	"github.com/linkernetworks/vortex/src/serviceprovider"
+	"net"
 	//	"gopkg.in/mgo.v2/bson"
 )
 
@@ -10,14 +12,24 @@ type NFSStorageProvider struct {
 	entity.NFSStorage
 }
 
-func (nfs NFSStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, network entity.Storage) error {
+func (nfs NFSStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, storage entity.Storage) error {
+	ip := net.ParseIP(storage.NFS.IP)
+	if len(ip) == 0 {
+		return fmt.Errorf("Invalid IP address %s\n", storage.NFS.IP)
+	}
+
+	path := storage.NFS.PATH
+	if path == "" || path[0] != '/' {
+		return fmt.Errorf("Invalid NFS export path %s\n", path)
+	}
+
 	return nil
 }
 
-func (nfs NFSStorageProvider) CreateStorage(sp *serviceprovider.Container, network entity.Storage) error {
+func (nfs NFSStorageProvider) CreateStorage(sp *serviceprovider.Container, storage entity.Storage) error {
 	return nil
 }
 
-func (nfs NFSStorageProvider) DeleteStorage(sp *serviceprovider.Container, network entity.Storage) error {
+func (nfs NFSStorageProvider) DeleteStorage(sp *serviceprovider.Container, storage entity.Storage) error {
 	return nil
 }

--- a/src/storageprovider/nfs.go
+++ b/src/storageprovider/nfs.go
@@ -12,14 +12,14 @@ import (
 	//	"gopkg.in/mgo.v2/bson"
 )
 
-const NFS_PROVISIONER_PREFIX = "nfs-provisioner"
-const NFS_STORAGECLASS_PREFIX = "nfs-storageclass"
+const NFS_PROVISIONER_PREFIX = "nfs-provisioner-"
+const NFS_STORAGECLASS_PREFIX = "nfs-storageclass-"
 
 type NFSStorageProvider struct {
 	entity.NFSStorage
 }
 
-func (nfs NFSStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, storage entity.Storage) error {
+func (nfs NFSStorageProvider) ValidateBeforeCreating(sp *serviceprovider.Container, storage *entity.Storage) error {
 	ip := net.ParseIP(storage.NFS.IP)
 	if len(ip) == 0 {
 		return fmt.Errorf("Invalid IP address %s\n", storage.NFS.IP)
@@ -86,17 +86,17 @@ func getDeployment(name string, storage *entity.Storage) *appsv1.Deployment {
 
 }
 
-func (nfs NFSStorageProvider) CreateStorage(sp *serviceprovider.Container, storage entity.Storage) error {
+func (nfs NFSStorageProvider) CreateStorage(sp *serviceprovider.Container, storage *entity.Storage) error {
 	name := NFS_PROVISIONER_PREFIX + storage.ID.Hex()
 
 	//Create deployment
-	deployment := getDeployment(name, &storage)
+	deployment := getDeployment(name, storage)
 	//Create storageClass
 	_, err := sp.KubeCtl.CreateDeployment(deployment)
 	return err
 }
 
-func (nfs NFSStorageProvider) DeleteStorage(sp *serviceprovider.Container, storage entity.Storage) error {
+func (nfs NFSStorageProvider) DeleteStorage(sp *serviceprovider.Container, storage *entity.Storage) error {
 	name := NFS_PROVISIONER_PREFIX + storage.ID.Hex()
 	//Delete StorageClass
 

--- a/src/storageprovider/nfs.go
+++ b/src/storageprovider/nfs.go
@@ -97,5 +97,9 @@ func (nfs NFSStorageProvider) CreateStorage(sp *serviceprovider.Container, stora
 }
 
 func (nfs NFSStorageProvider) DeleteStorage(sp *serviceprovider.Container, storage entity.Storage) error {
-	return nil
+	name := NFS_PROVISIONER_PREFIX + storage.ID.Hex()
+	//Delete StorageClass
+
+	//Delete Deployment
+	return sp.KubeCtl.DeleteDeployment(name)
 }

--- a/src/storageprovider/nfs.go
+++ b/src/storageprovider/nfs.go
@@ -42,6 +42,11 @@ func getDeployment(name string, storage *entity.Storage) *appsv1.Deployment {
 			Name: name,
 		},
 		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": name,
+				},
+			},
 			Replicas: &replicas,
 			Strategy: appsv1.DeploymentStrategy{
 				Type: appsv1.RecreateDeploymentStrategyType,

--- a/src/storageprovider/nfs_test.go
+++ b/src/storageprovider/nfs_test.go
@@ -58,7 +58,7 @@ func TestStorageSuite(t *testing.T) {
 func (suite *StorageTestSuite) TestGetDeployment() {
 	storage := &entity.Storage{
 		Type: entity.NFSStorageType,
-		NFS: entity.NFSStorage{
+		NFS: &entity.NFSStorage{
 			IP:   "1.2.3.4",
 			PATH: "/exports",
 		},
@@ -71,7 +71,7 @@ func (suite *StorageTestSuite) TestGetDeployment() {
 func (suite *StorageTestSuite) TestValidateBeforeCreating() {
 	storage := &entity.Storage{
 		Type: entity.NFSStorageType,
-		NFS: entity.NFSStorage{
+		NFS: &entity.NFSStorage{
 			IP:   "1.2.3.4",
 			PATH: "/exports",
 		},
@@ -90,7 +90,7 @@ func (suite *StorageTestSuite) TestCreateStorage() {
 	storage := entity.Storage{
 		ID:   bson.NewObjectId(),
 		Type: entity.NFSStorageType,
-		NFS: entity.NFSStorage{
+		NFS: &entity.NFSStorage{
 			IP:   "1.2.3.4",
 			PATH: "/exports",
 		},
@@ -112,7 +112,7 @@ func (suite *StorageTestSuite) TestDeleteStorage() {
 	storage := &entity.Storage{
 		ID:   bson.NewObjectId(),
 		Type: entity.NFSStorageType,
-		NFS: entity.NFSStorage{
+		NFS: &entity.NFSStorage{
 			IP:   "1.2.3.4",
 			PATH: "/exports",
 		},
@@ -144,20 +144,20 @@ func (suite *StorageTestSuite) TestValidateBeforeCreatingFail() {
 	}{
 		{"invalidIP", &entity.Storage{
 			Type: entity.NFSStorageType,
-			NFS: entity.NFSStorage{
+			NFS: &entity.NFSStorage{
 				IP: "a.b.c.d",
 			},
 		}},
 		{"invalidExports-1", &entity.Storage{
 			Type: entity.NFSStorageType,
-			NFS: entity.NFSStorage{
+			NFS: &entity.NFSStorage{
 				IP:   "1.2.3.4",
 				PATH: "tmp",
 			},
 		}},
 		{"invalidExports-2", &entity.Storage{
 			Type: entity.NFSStorageType,
-			NFS: entity.NFSStorage{
+			NFS: &entity.NFSStorage{
 				IP:   "1.2.3.4",
 				PATH: "",
 			},

--- a/src/storageprovider/nfs_test.go
+++ b/src/storageprovider/nfs_test.go
@@ -82,7 +82,7 @@ func (suite *StorageTestSuite) TestValidateBeforeCreating() {
 	suite.NoError(err)
 	sp = sp.(NFSStorageProvider)
 
-	err = sp.ValidateBeforeCreating(suite.sp, *storage)
+	err = sp.ValidateBeforeCreating(suite.sp, storage)
 	suite.NoError(err)
 }
 
@@ -100,7 +100,7 @@ func (suite *StorageTestSuite) TestCreateStorage() {
 	suite.NoError(err)
 	sp = sp.(NFSStorageProvider)
 
-	err = sp.CreateStorage(suite.sp, storage)
+	err = sp.CreateStorage(suite.sp, &storage)
 	suite.NoError(err)
 
 	deploy, err := suite.sp.KubeCtl.GetDeployment(NFS_PROVISIONER_PREFIX + storage.ID.Hex())
@@ -109,7 +109,7 @@ func (suite *StorageTestSuite) TestCreateStorage() {
 }
 
 func (suite *StorageTestSuite) TestDeleteStorage() {
-	storage := entity.Storage{
+	storage := &entity.Storage{
 		ID:   bson.NewObjectId(),
 		Type: entity.NFSStorageType,
 		NFS: entity.NFSStorage{
@@ -118,7 +118,7 @@ func (suite *StorageTestSuite) TestDeleteStorage() {
 		},
 	}
 
-	sp, err := GetStorageProvider(&storage)
+	sp, err := GetStorageProvider(storage)
 	suite.NoError(err)
 	sp = sp.(NFSStorageProvider)
 
@@ -171,7 +171,7 @@ func (suite *StorageTestSuite) TestValidateBeforeCreatingFail() {
 			suite.NoError(err)
 			np = np.(NFSStorageProvider)
 
-			err = np.ValidateBeforeCreating(suite.sp, *tc.storage)
+			err = np.ValidateBeforeCreating(suite.sp, tc.storage)
 			suite.Error(err)
 		})
 	}

--- a/src/storageprovider/storage.go
+++ b/src/storageprovider/storage.go
@@ -15,9 +15,9 @@ type StorageProvider interface {
 func GetStorageProvider(storage *entity.Storage) (StorageProvider, error) {
 	switch storage.Type {
 	case "nfs":
-		return NFSStorageProvider{storage.NFS}, nil
+		return NFSStorageProvider{*storage.NFS}, nil
 	case "fake":
-		return FakeStorageProvider{storage.Fake}, nil
+		return FakeStorageProvider{*storage.Fake}, nil
 	default:
 		return nil, fmt.Errorf("Unsupported Storage Type %s", storage.Type)
 	}

--- a/src/storageprovider/storage.go
+++ b/src/storageprovider/storage.go
@@ -7,9 +7,9 @@ import (
 )
 
 type StorageProvider interface {
-	ValidateBeforeCreating(sp *serviceprovider.Container, net entity.Storage) error
-	CreateStorage(sp *serviceprovider.Container, net entity.Storage) error
-	DeleteStorage(sp *serviceprovider.Container, net entity.Storage) error
+	ValidateBeforeCreating(sp *serviceprovider.Container, net *entity.Storage) error
+	CreateStorage(sp *serviceprovider.Container, net *entity.Storage) error
+	DeleteStorage(sp *serviceprovider.Container, net *entity.Storage) error
 }
 
 func GetStorageProvider(storage *entity.Storage) (StorageProvider, error) {

--- a/src/storageprovider/storage_test.go
+++ b/src/storageprovider/storage_test.go
@@ -24,6 +24,8 @@ func TestGetStorageProvider(t *testing.T) {
 			provider, err := GetStorageProvider(
 				&entity.Storage{
 					Type: tc.storageType,
+					Fake: &entity.FakeStorage{},
+					NFS:  &entity.NFSStorage{},
 				})
 			assert.NoError(t, err)
 			a := reflect.TypeOf(provider)


### PR DESCRIPTION
If the type is `nfs`, we will create a deployment like this.
```
kind: Deployment
apiVersion: extensions/v1beta1
metadata:
  name: nfs-client-provisioner
spec:
  replicas: 1
  strategy:
    type: Recreate
  template:
    metadata:
      labels:
        app: nfs-client-provisioner
    spec:
      serviceAccount: nfs-provisioner
      containers:
        - name: nfs-client-provisioner
          image: quay.io/kubernetes_incubator/nfs-provisioner:latest
            imagePullPolicy: IfNotPresent
          volumeMounts:
            - name: nfs-client-root
              mountPath: /persistentvolumes
          env:
            - name: PROVISIONER_NAME
              value: vortex.io/nfs
            - name: NFS_SERVER
              value: 192.168.6.135
            - name: NFS_PATH
              value: /exports
      volumes:
        - name: nfs-client-root
          nfs:
            server: 192.168.6.135
            path: /exports
```