### PR TITLE
Remove the parameter for fake network

### DIFF
--- a/src/entity/network.go
+++ b/src/entity/network.go
@@ -27,10 +27,6 @@ type PhyInterface struct {
 type Node struct {
 	Name          string         `bson:"name" json:"name"`
 	PhyInterfaces []PhyInterface `bson:"physicalInterfaces" json:"physicalInterfaces"`
-
-	// Fake fields for restful testing
-	FakeParameter string `json:"fakeParameter"`
-	ShouldFail    bool   `json:"shouldFail"`
 }
 
 type Network struct {

--- a/src/networkprovider/fake.go
+++ b/src/networkprovider/fake.go
@@ -8,27 +8,19 @@ import (
 )
 
 type fakeNetworkProvider struct {
-	networkName string
-	bridgeName  string
-	vlanTags    []int32
-	nodes       []entity.Node
-	isDPDKPort  bool
+	entity.Network
 }
 
 func (fnp fakeNetworkProvider) CreateNetwork(sp *serviceprovider.Container) error {
-	for _, node := range fnp.nodes {
-		if node.ShouldFail {
-			return fmt.Errorf("Fail to validate but don't worry, I'm fake network")
-		}
+	if !fnp.IsDPDKPort {
+		return fmt.Errorf("fail to validate but don't worry, I'm fake network")
 	}
 	return nil
 }
 
 func (fnp fakeNetworkProvider) DeleteNetwork(sp *serviceprovider.Container) error {
-	for _, node := range fnp.nodes {
-		if node.ShouldFail {
-			return fmt.Errorf("Fail to delete network but don't worry, I'm fake network")
-		}
+	if !fnp.IsDPDKPort {
+		return fmt.Errorf("fail to delete network but don't worry, I'm fake network")
 	}
 	return nil
 }

--- a/src/networkprovider/fake_test.go
+++ b/src/networkprovider/fake_test.go
@@ -10,13 +10,8 @@ import (
 
 func TestFakeNetworkCreating(t *testing.T) {
 	fake, err := GetNetworkProvider(&entity.Network{
-		Type: entity.FakeNetworkType,
-		Nodes: []entity.Node{
-			entity.Node{
-				FakeParameter: "yes",
-				ShouldFail:    false,
-			},
-		},
+		IsDPDKPort: true, // for fake testing
+		Type:       entity.FakeNetworkType,
 	})
 	assert.NoError(t, err)
 	err = fake.CreateNetwork(nil)
@@ -26,11 +21,6 @@ func TestFakeNetworkCreating(t *testing.T) {
 func TestFakeNetworkCreatingFail(t *testing.T) {
 	fake, err := GetNetworkProvider(&entity.Network{
 		Type: entity.FakeNetworkType,
-		Nodes: []entity.Node{
-			entity.Node{
-				ShouldFail: true,
-			},
-		},
 	})
 	assert.NoError(t, err)
 	err = fake.CreateNetwork(nil)
@@ -39,8 +29,8 @@ func TestFakeNetworkCreatingFail(t *testing.T) {
 
 func TestFakeNetworkDelete(t *testing.T) {
 	fake, err := GetNetworkProvider(&entity.Network{
-		Type:  entity.FakeNetworkType,
-		Nodes: []entity.Node{},
+		IsDPDKPort: true, // for fake testing
+		Type:       entity.FakeNetworkType,
 	})
 	assert.NoError(t, err)
 	err = fake.DeleteNetwork(nil)
@@ -50,11 +40,6 @@ func TestFakeNetworkDelete(t *testing.T) {
 func TestFakeNetworkDeleteFail(t *testing.T) {
 	fake, err := GetNetworkProvider(&entity.Network{
 		Type: entity.FakeNetworkType,
-		Nodes: []entity.Node{
-			entity.Node{
-				ShouldFail: true,
-			},
-		},
 	})
 	assert.NoError(t, err)
 	err = fake.DeleteNetwork(nil)

--- a/src/networkprovider/network.go
+++ b/src/networkprovider/network.go
@@ -16,29 +16,17 @@ func GetNetworkProvider(network *entity.Network) (NetworkProvider, error) {
 	switch network.Type {
 	case entity.OVSKernelspaceNetworkType:
 		return kernelspaceNetworkProvider{
-			network.Name,
-			network.BridgeName,
-			network.VLANTags,
-			network.Nodes,
-			network.IsDPDKPort,
+			*network,
 		}, nil
 	case entity.OVSUserspaceNetworkType:
 		return userspaceNetworkProvider{
-			network.Name,
-			network.BridgeName,
-			network.VLANTags,
-			network.Nodes,
-			network.IsDPDKPort,
+			*network,
 		}, nil
 	case entity.FakeNetworkType:
 		return fakeNetworkProvider{
-			network.Name,
-			network.BridgeName,
-			network.VLANTags,
-			network.Nodes,
-			network.IsDPDKPort,
+			*network,
 		}, nil
 	default:
-		return nil, fmt.Errorf("Unsupported Network Type %s", network.Type)
+		return nil, fmt.Errorf("unsupported Network Type %s", network.Type)
 	}
 }

--- a/src/networkprovider/ovs_netdev.go
+++ b/src/networkprovider/ovs_netdev.go
@@ -9,37 +9,33 @@ import (
 )
 
 type userspaceNetworkProvider struct {
-	networkName string
-	bridgeName  string
-	vlanTags    []int32
-	nodes       []entity.Node
-	isDPDKPort  bool
+	entity.Network
 }
 
 func (unp userspaceNetworkProvider) CreateNetwork(sp *serviceprovider.Container) error {
-	if err := entity.ValidateVLANTags(unp.vlanTags); err != nil {
+	if err := entity.ValidateVLANTags(unp.VLANTags); err != nil {
 		return err
 	}
-	for _, node := range unp.nodes {
+	for _, node := range unp.Nodes {
 		nodeIP, err := sp.KubeCtl.GetNodeExternalIP(node.Name)
 		if err != nil {
 			return err
 		}
-		if unp.isDPDKPort {
+		if unp.IsDPDKPort {
 			if err := createOVSDPDKNetwork(
 				nodeIP,
-				unp.bridgeName,
+				unp.BridgeName,
 				node.PhyInterfaces,
-				unp.vlanTags,
+				unp.VLANTags,
 			); err != nil {
 				return err
 			}
 		} else {
 			if err := createOVSUserspaceNetwork(
 				nodeIP,
-				unp.bridgeName,
+				unp.BridgeName,
 				node.PhyInterfaces,
-				unp.vlanTags,
+				unp.VLANTags,
 			); err != nil {
 				return err
 			}
@@ -49,14 +45,14 @@ func (unp userspaceNetworkProvider) CreateNetwork(sp *serviceprovider.Container)
 }
 
 func (unp userspaceNetworkProvider) DeleteNetwork(sp *serviceprovider.Container) error {
-	for _, node := range unp.nodes {
+	for _, node := range unp.Nodes {
 		nodeIP, err := sp.KubeCtl.GetNodeExternalIP(node.Name)
 		if err != nil {
 			return err
 		}
 		if err := deleteOVSUserspaceNetwork(
 			nodeIP,
-			unp.bridgeName,
+			unp.BridgeName,
 		); err != nil {
 			return err
 		}

--- a/src/networkprovider/ovs_system.go
+++ b/src/networkprovider/ovs_system.go
@@ -9,27 +9,23 @@ import (
 )
 
 type kernelspaceNetworkProvider struct {
-	networkName string
-	bridgeName  string
-	vlanTags    []int32
-	nodes       []entity.Node
-	isDPDKPort  bool
+	entity.Network
 }
 
 func (knp kernelspaceNetworkProvider) CreateNetwork(sp *serviceprovider.Container) error {
-	if err := entity.ValidateVLANTags(knp.vlanTags); err != nil {
+	if err := entity.ValidateVLANTags(knp.VLANTags); err != nil {
 		return err
 	}
-	for _, node := range knp.nodes {
+	for _, node := range knp.Nodes {
 		nodeIP, err := sp.KubeCtl.GetNodeExternalIP(node.Name)
 		if err != nil {
 			return err
 		}
 		if err := createOVSNetwork(
 			nodeIP,
-			knp.bridgeName,
+			knp.BridgeName,
 			node.PhyInterfaces,
-			knp.vlanTags,
+			knp.VLANTags,
 		); err != nil {
 			return err
 		}
@@ -38,14 +34,14 @@ func (knp kernelspaceNetworkProvider) CreateNetwork(sp *serviceprovider.Containe
 }
 
 func (knp kernelspaceNetworkProvider) DeleteNetwork(sp *serviceprovider.Container) error {
-	for _, node := range knp.nodes {
+	for _, node := range knp.Nodes {
 		nodeIP, err := sp.KubeCtl.GetNodeExternalIP(node.Name)
 		if err != nil {
 			return err
 		}
 		if err := deleteOVSNetwork(
 			nodeIP,
-			knp.bridgeName,
+			knp.BridgeName,
 		); err != nil {
 			return err
 		}

--- a/src/server/handler_network_test.go
+++ b/src/server/handler_network_test.go
@@ -53,13 +53,12 @@ func TestNetworkSuite(t *testing.T) {
 func (suite *NetworkTestSuite) TestCreateNetwork() {
 	tName := namesgenerator.GetRandomName(0)
 	network := entity.Network{
-		Type: entity.FakeNetworkType,
-		Name: tName,
+		Type:       entity.FakeNetworkType,
+		Name:       tName,
+		IsDPDKPort: true,                            // for fake network, true means success
+		BridgeName: namesgenerator.GetRandomName(0), // for fake network, true meas parameter good
 		Nodes: []entity.Node{
-			entity.Node{
-				Name:          "TestCreateNetwork",
-				FakeParameter: "fake",
-			},
+			{},
 		},
 	}
 
@@ -99,13 +98,11 @@ func (suite *NetworkTestSuite) TestCreateNetworkFail() {
 	}{
 		{"CreateFail",
 			entity.Network{
-				Name: namesgenerator.GetRandomName(0),
-				Type: entity.FakeNetworkType,
+				Name:       namesgenerator.GetRandomName(0),
+				BridgeName: namesgenerator.GetRandomName(0),
+				Type:       entity.FakeNetworkType,
 				Nodes: []entity.Node{
-					entity.Node{
-						FakeParameter: "Yo",
-						ShouldFail:    true,
-					},
+					entity.Node{},
 				},
 			},
 			http.StatusInternalServerError},
@@ -114,10 +111,7 @@ func (suite *NetworkTestSuite) TestCreateNetworkFail() {
 				Name: namesgenerator.GetRandomName(0),
 				Type: "none-exist",
 				Nodes: []entity.Node{
-					entity.Node{
-						FakeParameter: "Yo",
-						ShouldFail:    true,
-					},
+					entity.Node{},
 				},
 			},
 			http.StatusBadRequest},
@@ -144,9 +138,10 @@ func (suite *NetworkTestSuite) TestCreateNetworkFail() {
 func (suite *NetworkTestSuite) TestDeleteNetwork() {
 	tName := namesgenerator.GetRandomName(0)
 	network := entity.Network{
-		ID:   bson.NewObjectId(),
-		Name: tName,
-		Type: entity.FakeNetworkType,
+		ID:         bson.NewObjectId(),
+		IsDPDKPort: true, //for fake network, true means success,
+		Name:       tName,
+		Type:       entity.FakeNetworkType,
 		Nodes: []entity.Node{
 			entity.Node{
 				Name: "TestDeleteNetwork",
@@ -187,10 +182,7 @@ func (suite *NetworkTestSuite) TestDeleteNetworkFail() {
 			Name: namesgenerator.GetRandomName(0),
 			Type: entity.FakeNetworkType,
 			Nodes: []entity.Node{
-				entity.Node{
-					FakeParameter: "Yo",
-					ShouldFail:    true,
-				},
+				entity.Node{},
 			},
 		},
 			http.StatusInternalServerError},
@@ -200,10 +192,7 @@ func (suite *NetworkTestSuite) TestDeleteNetworkFail() {
 				Name: namesgenerator.GetRandomName(0),
 				Type: "none-exist",
 				Nodes: []entity.Node{
-					entity.Node{
-						FakeParameter: "Yo",
-						ShouldFail:    true,
-					},
+					entity.Node{},
 				},
 			},
 			http.StatusBadRequest},
@@ -235,8 +224,7 @@ func (suite *NetworkTestSuite) TestGetNetwork() {
 		Type: tType,
 		Nodes: []entity.Node{
 			entity.Node{
-				Name:          namesgenerator.GetRandomName(0),
-				FakeParameter: "fake",
+				Name: namesgenerator.GetRandomName(0),
 			},
 		},
 	}


### PR DESCRIPTION
Embed the entity.network to each network. we have already flatted all parameter for all network types.
