### PR TITLE
Add route entity & update generateClientCommand

### DIFF
--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -18,17 +18,24 @@ type Container struct {
 	Command []string `bson:"command" json:"command" validate:"required,dive,required"`
 }
 
-// PodNetwork is the structure for pod network info
-type PodNetwork struct {
-	Name       string `bson:"name" json:"name"`
-	IfName     string `bson:"ifName" json:"ifName"`
-	VlanTag    *int32 `bson:"vlanTag" json:"vlanTag"`
-	IPAddress  string `bson:"ipAddress" json:"ipAddress"`
-	Netmask    string `bson:"netmask" json:"netmask"`
-	BridgeName string `bson:"bridgeName" json:"bridgeName"` //its from the entity.Network entity
+// PodRoute is the structure for add IP routing table
+type PodRoute struct {
+	DstCIDR string `bson:"dstCIDR" json:"dstCIDR" validate:"required,cidr"`
+	Gateway string `bson:"gateway" json:"gateway" validate:"required,ip"`
 }
 
-// PodVolume is the structure for pof volume info 
+// PodNetwork is the structure for pod network info
+type PodNetwork struct {
+	Name       string     `bson:"name" json:"name"`
+	IfName     string     `bson:"ifName" json:"ifName"`
+	VlanTag    *int32     `bson:"vlanTag" json:"vlanTag"`
+	IPAddress  string     `bson:"ipAddress" json:"ipAddress"`
+	Netmask    string     `bson:"netmask" json:"netmask"`
+	Routes     []PodRoute `bson:"routes,omitempty" json:"routes"`
+	BridgeName string     `bson:"bridgeName" json:"bridgeName"` //its from the entity.Network entity
+}
+
+// PodVolume is the structure for pof volume info
 type PodVolume struct {
 	Name      string `bson:"name" json:"name" validate:"required"`
 	MountPath string `bson:"mountPath" json:"mountPath" validate:"required"`

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -35,7 +35,7 @@ type PodNetwork struct {
 	BridgeName string     `bson:"bridgeName" json:"bridgeName"` //its from the entity.Network entity
 }
 
-// PodVolume is the structure for pof volume info
+// PodVolume is the structure for pod volume info
 type PodVolume struct {
 	Name      string `bson:"name" json:"name" validate:"required"`
 	MountPath string `bson:"mountPath" json:"mountPath" validate:"required"`

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -104,6 +104,14 @@ func generateClientCommand(network entity.PodNetwork) (command []string) {
 	if network.VlanTag != nil {
 		command = append(command, "-v="+strconv.Itoa((int)(*network.VlanTag)))
 	}
+	// Support one command with one add route in first version
+	if network.Routes != nil {
+		if network.Routes[0].Gateway != "" {
+			command = append(command, "--net="+network.Routes[0].DstCIDR, "-g="+network.Routes[0].Gateway)
+		} else {
+			command = append(command, "--net="+network.Routes[0].DstCIDR)
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
Related issue: #154 
close #154 

- Update PodNetwork Entity: Add PodRoute structure & add a routes attribute.
- Fix typo of comment
- Update "generateClientCommand"  to support add route command. In this time, I just use array[0], because it's limited with Network-controller client the main function. 