### PR TITLE
[Task] Support hostnetwork option when creating Pod

### DIFF
--- a/API.md
+++ b/API.md
@@ -464,6 +464,8 @@ For each Pod, we have fileds need to handle.
 7. capability: the power of the container, if it's ture, it will get almost all capability and act as a privileged=true.
 8. restartPolicy: the attribute how the pod restart is container, it should be a string and only valid for those following strings.
     - Always,OnFailure,Never
+9. hostNetwork: the bool option to run the Pod in the host network namespace, if it's true, all values in the networks will be ignored.
+
 
 Example:
 

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -52,8 +52,8 @@ type Pod struct {
 	Volumes       []PodVolume       `bson:"volumes,omitempty" json:"volumes" validate:"required,dive,required"`
 	Networks      []PodNetwork      `bson:"networks,omitempty" json:"networks" validate:"required,dive,required"`
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
-	Capability    bool              `bson:"capability" json:"Capability" validate:"required"`
-	HostNetwork   bool              `bson:"hostNetwork" json:"hostNetwork" validate:"required"`
+	Capability    bool              `bson:"capability" json:"capability" validate:"-"`
+	HostNetwork   bool              `bson:"hostNetwork" json:"hostNetwork" validate:"-"`
 }
 
 // GetCollection - get model mongo collection name.

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -53,6 +53,7 @@ type Pod struct {
 	Networks      []PodNetwork      `bson:"networks,omitempty" json:"networks" validate:"required,dive,required"`
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
 	Capability    bool              `bson:"capability" json:"Capability" validate:"required"`
+	HostNetwork   bool              `bson:"hostNetwork" json:"hostNetwork" validate:"required"`
 }
 
 // GetCollection - get model mongo collection name.

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -231,9 +231,16 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 		return err
 	}
 
-	nodeNames, initContainers, err := generateNetwork(session, pod)
-	if err != nil {
-		return err
+	nodeNames := []string{}
+	initContainers := []corev1.Container{}
+	hostNetwork := false
+	if pod.HostNetwork {
+		hostNetwork = true
+	} else {
+		nodeNames, initContainers, err = generateNetwork(session, pod)
+		if err != nil {
+			return err
+		}
 	}
 
 	volumes = append(volumes, corev1.Volume{
@@ -268,6 +275,7 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 			Volumes:        volumes,
 			Affinity:       generateAffinity(nodeNames),
 			RestartPolicy:  corev1.RestartPolicy(pod.RestartPolicy),
+			HostNetwork:    hostNetwork,
 		},
 	}
 

--- a/src/server/handler_pod_test.go
+++ b/src/server/handler_pod_test.go
@@ -69,6 +69,7 @@ func (suite *PodTestSuite) TestCreatePod() {
 		Networks:      []entity.PodNetwork{},
 		Capability:    true,
 		RestartPolicy: "Never",
+		HostNetwork:   false,
 	}
 	bodyBytes, err := json.MarshalIndent(pod, "", "  ")
 	suite.NoError(err)

--- a/tests/pod.json
+++ b/tests/pod.json
@@ -36,5 +36,6 @@
 	],
 	"volumes":[],
     "restaryPolicy":"Always",
-    "capability": true
+    "capability": true,
+    "hostNetwork":false
 }


### PR DESCRIPTION
For some case, the Pod wants to use the hostNetwork rather than any bridge-like network.
