### PR TITLE
[Bug] Change the timeout to 10 seconds

### DIFF
--- a/src/networkcontroller/network_controller.go
+++ b/src/networkcontroller/network_controller.go
@@ -26,7 +26,7 @@ func New(serverAddress string) (*NetworkController, error) {
 		return nil, err
 	}
 
-	ctx, _ := context.WithTimeout(context.Background(), time.Second)
+	ctx, _ := context.WithTimeout(context.Background(), 10*time.Second)
 
 	return &NetworkController{
 		ClientCtl: pb.NewNetworkControlClient(conn),


### PR DESCRIPTION
We will meet the random testing fail in the travis CI environment.
The message is context deadline exceeded and We thinks it's caused by the client didn't get the response from the grpc Server in a timeout value.
The current value is one second and we try to change to ten seconds to validate our guess.