### PR TITLE
 [TASK] Support the PodNetworkType and NodeAffinity filed in the pod entity.

### DIFF
--- a/API.md
+++ b/API.md
@@ -617,7 +617,8 @@ For each Pod, we have fileds need to handle.
 7. capability: the power of the container, if it's ture, it will get almost all capability and act as a privileged=true.
 8. restartPolicy: the attribute how the pod restart is container, it should be a string and only valid for those following strings.
     - Always,OnFailure,Never
-9. hostNetwork: the bool option to run the Pod in the host network namespace, if it's true, all values in the networks will be ignored.
+9. networkType: the string options for network type, support "host", "custom" and "cluster".
+10. nodeAffinity: the string array to indicate whchi nodes I want my Pod can run in.
 
 
 Example:
@@ -642,7 +643,9 @@ Request Data:
   },
   "volumes":[
   ],
-  "capability":true
+  "capability":true,
+  "networkType":"host",
+  "nodeAffinity":[]
 }
 ```
 

--- a/API.md
+++ b/API.md
@@ -646,6 +646,7 @@ Request Data:
   "capability":true,
   "networkType":"host",
   "nodeAffinity":[]
+  ]
 }
 ```
 

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -60,7 +60,6 @@ type Pod struct {
 	Networks      []PodNetwork      `bson:"networks,omitempty" json:"networks" validate:"required,dive,required"`
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
 	Capability    bool              `bson:"capability" json:"capability" validate:"-"`
-	HostNetwork   bool              `bson:"hostNetwork" json:"hostNetwork" validate:"-"`
 	NetworkType   string            `bson:"networkType" json:"networkType" validate:"required,eq=Host|Cluster|Custom`
 }
 

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -6,12 +6,16 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
-// PodCollectionName's const
 const (
+	// PodCollectionName's const
 	PodCollectionName string = "pods"
-	PodHostNetwork           = "host"
-	PodClusterNetwork        = "cluster"
-	PodCustomNetwork         = "custom"
+	// The network type for the Pod
+	// host means the pod use the hostNetwork (share the network with the host machine)
+	PodHostNetwork = "host"
+	// cluster means use the cluster Network, maybe the flannel network
+	PodClusterNetwork = "cluster"
+	// custom means the custom netwokr we created before, it support the OVS and DPDK network for additional network interface card
+	PodCustomNetwork = "custom"
 )
 
 // Container is the structure for init Container info

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -60,7 +60,7 @@ type Pod struct {
 	Networks      []PodNetwork      `bson:"networks,omitempty" json:"networks" validate:"required,dive,required"`
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
 	Capability    bool              `bson:"capability" json:"capability" validate:"-"`
-	NetworkType   string            `bson:"networkType" json:"networkType" validate:"required,eq=Host|Cluster|Custom`
+	NetworkType   string            `bson:"networkType" json:"networkType" validate:"required,eq=host|cluster|custom`
 	NodeAffinity  []string          `bson:"nodeAffinity" json:"nodeAffinity" validate:"required"`
 }
 

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -61,6 +61,7 @@ type Pod struct {
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
 	Capability    bool              `bson:"capability" json:"capability" validate:"-"`
 	NetworkType   string            `bson:"networkType" json:"networkType" validate:"required,eq=Host|Cluster|Custom`
+	NodeAffinity  []string          `bson:"nodeAffinity" json:"nodeAffinity" validate:"required"`
 }
 
 // GetCollection - get model mongo collection name.

--- a/src/entity/pod.go
+++ b/src/entity/pod.go
@@ -9,6 +9,9 @@ import (
 // PodCollectionName's const
 const (
 	PodCollectionName string = "pods"
+	PodHostNetwork           = "host"
+	PodClusterNetwork        = "cluster"
+	PodCustomNetwork         = "custom"
 )
 
 // Container is the structure for init Container info
@@ -54,6 +57,7 @@ type Pod struct {
 	RestartPolicy string            `bson:"restartPolicy" json:"restartPolicy" validate:"required,eq=Always|eq=OnFailure|eq=Never`
 	Capability    bool              `bson:"capability" json:"capability" validate:"-"`
 	HostNetwork   bool              `bson:"hostNetwork" json:"hostNetwork" validate:"-"`
+	NetworkType   string            `bson:"networkType" json:"networkType" validate:"required,eq=Host|Cluster|Custom`
 }
 
 // GetCollection - get model mongo collection name.

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -231,7 +231,7 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 		return err
 	}
 
-	nodeNames := pod.NodeAffinity
+	nodeAffinity := pod.NodeAffinity
 	initContainers := []corev1.Container{}
 	hostNetwork := false
 	switch pod.NetworkType {
@@ -241,10 +241,10 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 		tmp := []string{}
 		tmp, initContainers, err = generateNetwork(session, pod)
 		if len(tmp) != 0 {
-			nodeNames = utils.Intersection(nodeNames, tmp)
+			nodeAffinity = utils.Intersection(nodeAffinity, tmp)
 		}
 	case entity.PodClusterNetwork:
-		//For cluster network, we won't set the nodeAffinity and any netwokr options.
+		//For cluster network, we won't set the nodeAffinity and any network options.
 	default:
 		err = fmt.Errorf("UnSupported Pod NetworkType %s", pod.NetworkType)
 	}
@@ -283,7 +283,7 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 			InitContainers: initContainers,
 			Containers:     containers,
 			Volumes:        volumes,
-			Affinity:       generateAffinity(nodeNames),
+			Affinity:       generateAffinity(nodeAffinity),
 			RestartPolicy:  corev1.RestartPolicy(pod.RestartPolicy),
 			HostNetwork:    hostNetwork,
 		},

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -231,19 +231,22 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 		return err
 	}
 
-	nodeNames := []string{}
+	nodeNames := pod.NodeAffinity
 	initContainers := []corev1.Container{}
 	hostNetwork := false
 	switch pod.NetworkType {
 	case entity.PodHostNetwork:
 		hostNetwork = true
 	case entity.PodCustomNetwork:
-		nodeNames, initContainers, err = generateNetwork(session, pod)
+		tmp := []string{}
+		tmp, initContainers, err = generateNetwork(session, pod)
+		nodeNames = utils.Intersection(nodeNames, tmp)
 	case entity.PodClusterNetwork:
 		//For cluster network, we won't set the nodeAffinity and any netwokr options.
 	default:
 		err = fmt.Errorf("UnSupported Pod NetworkType %s", pod.NetworkType)
 	}
+
 	if err != nil {
 		return err
 	}

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -234,13 +234,18 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 	nodeNames := []string{}
 	initContainers := []corev1.Container{}
 	hostNetwork := false
-	if pod.HostNetwork {
+	switch pod.NetworkType {
+	case entity.PodHostNetwork:
 		hostNetwork = true
-	} else {
+	case entity.PodCustomNetwork:
 		nodeNames, initContainers, err = generateNetwork(session, pod)
-		if err != nil {
-			return err
-		}
+	case entity.PodClusterNetwork:
+		//For cluster network, we won't set the nodeAffinity and any netwokr options.
+	default:
+		err = fmt.Errorf("UnSupported Pod NetworkType %s", pod.NetworkType)
+	}
+	if err != nil {
+		return err
 	}
 
 	volumes = append(volumes, corev1.Volume{

--- a/src/pod/pod.go
+++ b/src/pod/pod.go
@@ -240,7 +240,9 @@ func CreatePod(sp *serviceprovider.Container, pod *entity.Pod) error {
 	case entity.PodCustomNetwork:
 		tmp := []string{}
 		tmp, initContainers, err = generateNetwork(session, pod)
-		nodeNames = utils.Intersection(nodeNames, tmp)
+		if len(tmp) != 0 {
+			nodeNames = utils.Intersection(nodeNames, tmp)
+		}
 	case entity.PodClusterNetwork:
 		//For cluster network, we won't set the nodeAffinity and any netwokr options.
 	default:

--- a/src/pod/pod_test.go
+++ b/src/pod/pod_test.go
@@ -348,3 +348,95 @@ func (suite *PodTestSuite) TestGenerateContainerSecurityContext() {
 	suite.NotNil(security.Privileged)
 	suite.NotNil(security.Capabilities)
 }
+
+func (suite *PodTestSuite) TestCreatePodWithNetworkTypes() {
+
+	networkName := namesgenerator.GetRandomName(0)
+	bName := namesgenerator.GetRandomName(0)
+	network := entity.Network{
+		ID:         bson.NewObjectId(),
+		Name:       networkName,
+		BridgeName: bName,
+		Nodes: []entity.Node{
+			{Name: "node1"},
+			{Name: "node2"},
+			{Name: "node3"},
+		},
+	}
+	session := suite.sp.Mongo.NewSession()
+	defer session.Close()
+
+	session.Insert(entity.NetworkCollectionName, network)
+	defer session.Remove(entity.NetworkCollectionName, "name", network.Name)
+
+	//For each case, we need to check the
+	//HostNetwork object
+	//NodeAffinity object
+	//Create Success
+	testCases := []struct {
+		caseName      string
+		pod           *entity.Pod
+		rHostNetwork  bool     //result of hostNetwork
+		rNodeAffinity []string //result of rNodeAffinity
+	}{
+		{
+			"hostNetwork",
+			&entity.Pod{
+				ID:           bson.NewObjectId(),
+				Name:         namesgenerator.GetRandomName(0),
+				Containers:   []entity.Container{},
+				NetworkType:  entity.PodHostNetwork,
+				NodeAffinity: []string{"node1", "node2"},
+			},
+			true,
+			[]string{"node1", "node2"},
+		},
+		{
+			"clusterNetwork",
+			&entity.Pod{
+				ID:           bson.NewObjectId(),
+				Name:         namesgenerator.GetRandomName(0),
+				Containers:   []entity.Container{},
+				NetworkType:  entity.PodClusterNetwork,
+				NodeAffinity: []string{"node1", "node2"},
+			},
+			false,
+			[]string{"node1", "node2"},
+		},
+		{
+			"customNetwork",
+			&entity.Pod{
+				ID:          bson.NewObjectId(),
+				Name:        namesgenerator.GetRandomName(0),
+				Containers:  []entity.Container{},
+				NetworkType: entity.PodCustomNetwork,
+				Networks: []entity.PodNetwork{
+					{
+						Name: networkName,
+					},
+				},
+				NodeAffinity: []string{"node1", "node5"},
+			},
+			false,
+			[]string{"node1"},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.T().Run(tc.caseName, func(t *testing.T) {
+			err := CreatePod(suite.sp, tc.pod)
+			suite.NoError(err)
+
+			pod, err := suite.sp.KubeCtl.GetPod(tc.pod.Name, tc.pod.Namespace)
+			suite.NotNil(pod)
+			suite.NoError(err)
+
+			suite.Equal(tc.rHostNetwork, pod.Spec.HostNetwork)
+			suite.Equal(tc.rNodeAffinity, pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions[0].Values)
+
+			err = DeletePod(suite.sp, tc.pod)
+			suite.NoError(err)
+
+		})
+	}
+}

--- a/src/pod/pod_test.go
+++ b/src/pod/pod_test.go
@@ -152,9 +152,10 @@ func (suite *PodTestSuite) TestCreatePod() {
 
 	podName := namesgenerator.GetRandomName(0)
 	pod := &entity.Pod{
-		ID:         bson.NewObjectId(),
-		Name:       podName,
-		Containers: containers,
+		ID:          bson.NewObjectId(),
+		Name:        podName,
+		Containers:  containers,
+		NetworkType: entity.PodHostNetwork,
 	}
 
 	err := CreatePod(suite.sp, pod)

--- a/src/server/handler_pod_test.go
+++ b/src/server/handler_pod_test.go
@@ -243,7 +243,7 @@ func (suite *PodTestSuite) TestGetPodWithInvalidID() {
 }
 
 func (suite *PodTestSuite) TestListPod() {
-	/*namespace := "default"
+	namespace := "default"
 	pods := []entity.Pod{}
 	count := 3
 	for i := 0; i < count; i++ {
@@ -302,7 +302,7 @@ func (suite *PodTestSuite) TestListPod() {
 				suite.Equal(len(pods[i].Containers), len(p.Containers))
 			}
 		})
-	}*/
+	}
 }
 
 func (suite *PodTestSuite) TestListPodWithInvalidPage() {

--- a/src/server/handler_pod_test.go
+++ b/src/server/handler_pod_test.go
@@ -152,10 +152,13 @@ func (suite *PodTestSuite) TestDeletePod() {
 	}
 	tName := namesgenerator.GetRandomName(0)
 	pod := entity.Pod{
-		ID:         bson.NewObjectId(),
-		Name:       tName,
-		Namespace:  namespace,
-		Containers: containers,
+		ID:            bson.NewObjectId(),
+		Name:          tName,
+		Namespace:     namespace,
+		Containers:    containers,
+		Capability:    true,
+		RestartPolicy: "Never",
+		NetworkType:   entity.PodHostNetwork,
 	}
 
 	err := p.CreatePod(suite.sp, &pod)
@@ -238,7 +241,7 @@ func (suite *PodTestSuite) TestGetPodWithInvalidID() {
 }
 
 func (suite *PodTestSuite) TestListPod() {
-	namespace := "default"
+	/*namespace := "default"
 	pods := []entity.Pod{}
 	count := 3
 	for i := 0; i < count; i++ {
@@ -297,7 +300,7 @@ func (suite *PodTestSuite) TestListPod() {
 				suite.Equal(len(pods[i].Containers), len(p.Containers))
 			}
 		})
-	}
+	}*/
 }
 
 func (suite *PodTestSuite) TestListPodWithInvalidPage() {

--- a/src/server/handler_pod_test.go
+++ b/src/server/handler_pod_test.go
@@ -70,6 +70,7 @@ func (suite *PodTestSuite) TestCreatePod() {
 		Capability:    true,
 		RestartPolicy: "Never",
 		NetworkType:   entity.PodHostNetwork,
+		NodeAffinity:  []string{},
 	}
 	bodyBytes, err := json.MarshalIndent(pod, "", "  ")
 	suite.NoError(err)
@@ -159,6 +160,7 @@ func (suite *PodTestSuite) TestDeletePod() {
 		Capability:    true,
 		RestartPolicy: "Never",
 		NetworkType:   entity.PodHostNetwork,
+		NodeAffinity:  []string{},
 	}
 
 	err := p.CreatePod(suite.sp, &pod)

--- a/src/server/handler_pod_test.go
+++ b/src/server/handler_pod_test.go
@@ -69,7 +69,7 @@ func (suite *PodTestSuite) TestCreatePod() {
 		Networks:      []entity.PodNetwork{},
 		Capability:    true,
 		RestartPolicy: "Never",
-		HostNetwork:   false,
+		NetworkType:   entity.PodHostNetwork,
 	}
 	bodyBytes, err := json.MarshalIndent(pod, "", "  ")
 	suite.NoError(err)

--- a/tests/01-multiple-interface/pod.info
+++ b/tests/01-multiple-interface/pod.info
@@ -37,5 +37,6 @@
 	"volumes":[],
     "restaryPolicy":"Always",
     "capability": true,
-    "networkType": "custom"
+    "networkType": "custom",
+	"nodeAffinity": []
 }

--- a/tests/01-multiple-interface/pod.info
+++ b/tests/01-multiple-interface/pod.info
@@ -37,5 +37,5 @@
 	"volumes":[],
     "restaryPolicy":"Always",
     "capability": true,
-    "hostNetwork":false
+    "networkType": "custom"
 }

--- a/tests/02-hoet-network/pod.info
+++ b/tests/02-hoet-network/pod.info
@@ -14,5 +14,5 @@
 	"volumes":[],
     "restaryPolicy":"Always",
     "capability": true,
-    "hostNetwork": true
+    "networkType": "host"
 }

--- a/tests/02-hoet-network/pod.info
+++ b/tests/02-hoet-network/pod.info
@@ -14,5 +14,6 @@
 	"volumes":[],
     "restaryPolicy":"Always",
     "capability": true,
-    "networkType": "host"
+    "networkType": "host",
+	"nodeAffinity": []
 }


### PR DESCRIPTION
In the pod entity, we use the PodNetworkType to choose what kind of the network the Pod use and use the `nodeAffinity` to indicate which nodes it wants to run.