### PR TITLE
[BUG] Mount the ovs directory for tcp-network-controller

### DIFF
--- a/deploy/helm/apps/charts/network-controller/templates/tcp-daemonset.yaml
+++ b/deploy/helm/apps/charts/network-controller/templates/tcp-daemonset.yaml
@@ -25,13 +25,13 @@ spec:
         volumeMounts:
         - mountPath: /var/run/docker.sock
           name: docker-sock
-        - mountPath: /var/run/openvswitch/db.sock
-          name: ovs-sock
+        - mountPath: /var/run/openvswitch/
+          name: ovs-data
       volumes:
       - name: docker-sock
         hostPath:
           path: /run/docker.sock
-      - name: ovs-sock
+      - name: ovs-data #for some operations(dump ports) it needs extra unix socker to handle, so we mount whole ovs directory
         hostPath:
-          path: /run/openvswitch/db.sock
+          path: /run/openvswitch/
       hostNetwork: true

--- a/deploy/helm/apps/charts/network-controller/templates/unix-daemonset.yaml
+++ b/deploy/helm/apps/charts/network-controller/templates/unix-daemonset.yaml
@@ -39,7 +39,7 @@ spec:
       - name: docker-sock
         hostPath:
           path: /run/docker.sock
-      - name: ovs-sock
+      - name: ovs-sock #since the UNIX version only add-port, the db.sock is enough
         hostPath:
           path: /run/openvswitch/db.sock
       - name: grpc-sock


### PR DESCRIPTION
Use the DumpOVSPorts in the network-controller, we will get the following error message.
`Failed to dump ports: exit status 1: ovs-ofctl: peaceful_cori is not a bridge or a socket`
The reason is that we don't have the peaceful_cori.mgnt unix socker in the network-controller container.

So, we should mount whole ovs directory into the container.