### PR TITLE
Update scrape_timeout to 30s

### DIFF
--- a/deploy/helm/apps/charts/prometheus/templates/config.yaml
+++ b/deploy/helm/apps/charts/prometheus/templates/config.yaml
@@ -16,7 +16,7 @@ data:
     
     global:
       scrape_interval: {{ .Values.controller.scrapeInterval }}
-      scrape_timeout: 5s
+      scrape_timeout: 30s
 
     rule_files:
     - /etc/prometheus-rules/rules.yml


### PR DESCRIPTION
sometimes it takes more than 5s to scrape the metrics